### PR TITLE
[FIX] Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Zenaton library for Node lets you code and launch workflows using Zenaton p
 
 ## Requirements
 
-Node 5 and later.
+Node 6 and later.
 
 ## Installation
 
@@ -81,4 +81,4 @@ where `.env` is the env file containing your credentials, and `boot.js` is a fil
 
 ## Documentation
 
-Please see https://zenaton.com/documentation for complete documentation.
+Please see https://zenaton.com/documentation?lang=node# for complete documentation.


### PR DESCRIPTION
- zenaton node package doesn't support node 5 as block scoped declaractions are not supported in it. Also, zenaton's dependencies require node 6 atleast.
- Link documentation URL to node documentation directly.