### PR TITLE
Add input key and set data value to empty object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
-- Tasks and workflows scheduling in new syntax
+- Tasks and workflows scheduling in new syntax.
+- Added an `input` key for dispatch workflow and schedule workflow.
 
 ### Changed
 
@@ -16,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Time/Duration methods don't have anymore `1` as default value.
 - Time/Duration methods can't be stacked, works now like mutators.
 - Better uses of capitalize convention: initial caps limited to constructors
+- Changed `data` value for dispatch workflow and schedule workflow to empty object.
 
 ### Deprecated
 

--- a/src/Code/201908_draft/Client/Alfred.js
+++ b/src/Code/201908_draft/Client/Alfred.js
@@ -18,7 +18,9 @@ const ATTR_CUSTOM_ID = "custom_id";
 const ATTR_NAME = "name";
 const ATTR_CANONICAL = "canonical_name";
 const ATTR_VERSION = "version";
-const ATTR_INPUT = "data";
+const ATTR_INPUT = "input";
+const ATTR_PROPERTIES = "properties";
+
 const ATTR_PROG = "programming_language";
 const ATTR_INITIAL_LIB_VERSION = "initial_library_version";
 const ATTR_CODE_PATH_VERSION = "code_path_version";
@@ -97,7 +99,8 @@ const Alfred = class Alfred {
         customId: body[ATTR_CUSTOM_ID],
         canonicalName: body[ATTR_CANONICAL],
         programmingLanguage: body[ATTR_PROG].toUpperCase(),
-        data: body[ATTR_INPUT],
+        input: body[ATTR_INPUT],
+        data: body[ATTR_PROPERTIES],
         codePathVersion: body[ATTR_CODE_PATH_VERSION],
         initialLibraryVersion: body[ATTR_INITIAL_LIB_VERSION],
       },
@@ -122,7 +125,8 @@ const Alfred = class Alfred {
         workflowName: body[ATTR_NAME],
         canonicalName: body[ATTR_CANONICAL],
         programmingLanguage: body[ATTR_PROG].toUpperCase(),
-        properties: body[ATTR_INPUT],
+        input: body[ATTR_INPUT],
+        properties: body[ATTR_PROPERTIES],
         codePathVersion: body[ATTR_CODE_PATH_VERSION],
         initialLibraryVersion: body[ATTR_INITIAL_LIB_VERSION],
       },
@@ -311,6 +315,7 @@ const Alfred = class Alfred {
       [ATTR_CANONICAL]: canonical,
       [ATTR_VERSION]: version,
       [ATTR_INPUT]: serializer.encode(job.input),
+      [ATTR_PROPERTIES]: serializer.encode({}),
       [ATTR_CUSTOM_ID]: job.customId ? job.customId : null,
     };
   }


### PR DESCRIPTION
before the new syntax:

- data was in fact the initial properties of the workflow, because we were instantiating the workflow class. 

With the new syntax, the data sent to Alfred are in fact simple input, and properties are not known at this stage. 

That's why:

data become `{}` and I added an `input` key, to store the data sent with the dispatch 