### PR TITLE
fix duration and datetime get method for null

### DIFF
--- a/src/Code/201908_draft/Decider/Wait.js
+++ b/src/Code/201908_draft/Decider/Wait.js
@@ -11,7 +11,8 @@ const Wait = class Wait {
   }
 
   forever() {
-    this.duration = null;
+    // http://ecma-international.org/ecma-262/5.1/#sec-15.9.1.1
+    this.timestamp = 8640000000;
 
     return this._apply();
   }

--- a/src/Code/201908_draft/Services/DateTime.js
+++ b/src/Code/201908_draft/Services/DateTime.js
@@ -178,6 +178,8 @@ class DateTime {
   }
 
   get(definition, baseDate) {
+    if (definition === null) return null;
+
     const timeDefinition = definition || this._getDefinition();
 
     if (Number.isInteger(timeDefinition)) {

--- a/src/Code/201908_draft/Services/Duration.js
+++ b/src/Code/201908_draft/Services/Duration.js
@@ -111,6 +111,8 @@ class Duration {
   }
 
   get(definition, baseDate) {
+    if (definition === null) return null;
+
     const durationDefinition = definition || this._getDefinition();
 
     if (Number.isInteger(durationDefinition)) {


### PR DESCRIPTION
`datetime.get(null)` and `duration.get(null)` return now null.

You can always test with `datetime.get()` but we lose the ability to test with a base date at second parameters. Of course, we can add a test like `definition === null && !baseDate`, but `baseDate`is an undocumented feature, only used by tests with a provided definition...
So imho this very little check will introduce useless complexity.

This choice is a good tradeoff, compared to the previous check of null directly in the agent.