### PR TITLE
Throw exception for non standard connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Added
+
+- Return an exception when the user gives a non standard Zenaton connector ID.
+
 ### Changed
 
 - Require the `ZENATON_CODE_PATH` dynamically depending the `ZENATON_LAST_CODE_PATH`.

--- a/src/Code/serverless/Client/Connector.js
+++ b/src/Code/serverless/Client/Connector.js
@@ -1,11 +1,14 @@
 const uuidv4 = require("uuid/v4");
 const { ExternalZenatonError } = require("../../../Errors");
 
+const ZENATON_CONNECTOR_ID_PATTERN_LENGTH = 5;
+
 const Connector = class Connector {
   constructor(service, serviceId, processor) {
     this._checkString(service, "First", "connector's name");
     if (service !== "http") {
       this._checkString(serviceId, "Second", "connector's id");
+      this._checkServiceIdPattern(serviceId);
     }
 
     this._service = service;
@@ -71,6 +74,15 @@ const Connector = class Connector {
     if (typeof val !== "string" || val.length > 128) {
       throw new ExternalZenatonError(
         `${position} parameter of "${this._service}.${method}" (${type}) must have less than 128 characters"`,
+      );
+    }
+  }
+
+  // At this point we know that serviceId is a string because of ☝️
+  _checkServiceIdPattern(serviceId) {
+    if (serviceId.split("-").length !== ZENATON_CONNECTOR_ID_PATTERN_LENGTH) {
+      throw new ExternalZenatonError(
+        `The current given connectorId "${serviceId}" is not corresponding to a Zenaton connector Id, you should check at https://zenaton.com/documentation/node/api-connectors#use-connectors`,
       );
     }
   }

--- a/src/Code/serverless/Client/Connector.js
+++ b/src/Code/serverless/Client/Connector.js
@@ -1,8 +1,6 @@
 const uuidv4 = require("uuid/v4");
 const { ExternalZenatonError } = require("../../../Errors");
 
-const ZENATON_CONNECTOR_ID_PATTERN_LENGTH = 5;
-
 const Connector = class Connector {
   constructor(service, serviceId, processor) {
     this._checkString(service, "First", "connector's name");
@@ -78,9 +76,14 @@ const Connector = class Connector {
     }
   }
 
+  _isUUID(str) {
+    const UUIDPattern = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
+    return UUIDPattern.test(str);
+  }
+
   // At this point we know that serviceId is a string because of ☝️
   _checkServiceIdPattern(serviceId) {
-    if (serviceId.split("-").length !== ZENATON_CONNECTOR_ID_PATTERN_LENGTH) {
+    if (!this._isUUID(serviceId)) {
       throw new ExternalZenatonError(
         `The current given connectorId "${serviceId}" is not corresponding to a Zenaton connector Id, you should check at https://zenaton.com/documentation/node/api-connectors#use-connectors`,
       );

--- a/src/Code/yield/Client/Connector.js
+++ b/src/Code/yield/Client/Connector.js
@@ -1,11 +1,14 @@
 const uuidv4 = require("uuid/v4");
 const { ExternalZenatonError } = require("../../../Errors");
 
+const ZENATON_CONNECTOR_ID_PATTERN_LENGTH = 5;
+
 const Connector = class Connector {
   constructor(service, serviceId, processor) {
     this._checkString(service, "First", "connector's name");
     if (service !== "http") {
       this._checkString(serviceId, "Second", "connector's id");
+      this._checkServiceIdPattern(serviceId);
     }
 
     this._service = service;
@@ -71,6 +74,15 @@ const Connector = class Connector {
     if (typeof val !== "string" || val.length > 128) {
       throw new ExternalZenatonError(
         `${position} parameter of "${this._service}.${method}" (${type}) must have less than 128 characters"`,
+      );
+    }
+  }
+
+  // At this point we know that serviceId is a string because of ☝️
+  _checkServiceIdPattern(serviceId) {
+    if (serviceId.split("-").length !== ZENATON_CONNECTOR_ID_PATTERN_LENGTH) {
+      throw new ExternalZenatonError(
+        `The current given connectorId "${serviceId}" is not corresponding to a Zenaton connector Id, you should check at https://zenaton.com/documentation/node/api-connectors#use-connectors`,
       );
     }
   }

--- a/src/Code/yield/Client/Connector.js
+++ b/src/Code/yield/Client/Connector.js
@@ -1,8 +1,6 @@
 const uuidv4 = require("uuid/v4");
 const { ExternalZenatonError } = require("../../../Errors");
 
-const ZENATON_CONNECTOR_ID_PATTERN_LENGTH = 5;
-
 const Connector = class Connector {
   constructor(service, serviceId, processor) {
     this._checkString(service, "First", "connector's name");
@@ -78,9 +76,14 @@ const Connector = class Connector {
     }
   }
 
+  _isUUID(str) {
+    const UUIDPattern = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
+    return UUIDPattern.test(str);
+  }
+
   // At this point we know that serviceId is a string because of ☝️
   _checkServiceIdPattern(serviceId) {
-    if (serviceId.split("-").length !== ZENATON_CONNECTOR_ID_PATTERN_LENGTH) {
+    if (!this._isUUID(serviceId)) {
       throw new ExternalZenatonError(
         `The current given connectorId "${serviceId}" is not corresponding to a Zenaton connector Id, you should check at https://zenaton.com/documentation/node/api-connectors#use-connectors`,
       );


### PR DESCRIPTION
Asked by Gilles for the end of the year.

If you run a workflow with a non-standard Zenaton connector ID, let's say : `MY_ZENATON_CONNECTOR_ID`, it will throw an exception during the decision execution, so you will be warned. If you change the ID and retry it will work out perfectly;

Feel free to give your opinion on the implementation