### PR TITLE
Change the decode method of the yield code path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Require the `ZENATON_CODE_PATH` dynamically depending the `ZENATON_LAST_CODE_PATH`.
 - Updated versioner in `yield`and `serverless`code path to return also the original name
 - Update behavior of `get` function in WorkflowManager
+- Changed the decode method to accept `JSON` of the `yield` Serializer.
 
 ## 0.7.2 - 2019-10-23
 

--- a/src/Code/yield/Services/Serializer.js
+++ b/src/Code/yield/Services/Serializer.js
@@ -26,7 +26,19 @@ function encode(data) {
 function decode(data) {
   const parsedData = JSON.parse(data);
 
-  return decodeData(parsedData);
+  return isZenatonSerializerFormat(parsedData)
+    ? decodeData(parsedData)
+    : parsedData;
+}
+
+function isZenatonSerializerFormat(data) {
+  // required s & v key containing the current version and optionnally a d key or o key
+  return (
+    "s" in data &&
+    "v" in data &&
+    data.v === CURRENT_VERSION &&
+    ("d" in data || ("o" in data && data.o.includes(ZENATON_PREFIX)))
+  );
 }
 
 function encodeData(data) {

--- a/src/Code/yield/Services/Serializer.js
+++ b/src/Code/yield/Services/Serializer.js
@@ -36,7 +36,6 @@ function isZenatonSerializerFormat(data) {
   return (
     "s" in data &&
     "v" in data &&
-    data.v === CURRENT_VERSION &&
     ("d" in data || ("o" in data && data.o.includes(ZENATON_PREFIX)))
   );
 }

--- a/test/yield/Services/Serializer.js
+++ b/test/yield/Services/Serializer.js
@@ -1,0 +1,63 @@
+const { expect } = require("chai");
+
+const {
+  decode,
+  CURRENT_VERSION,
+} = require("../../../src/Code/yield/Services/Serializer");
+
+describe("Decode Serializer for yield path", () => {
+  function getDataAsString(data) {
+    return JSON.stringify({
+      ...data,
+      v: CURRENT_VERSION,
+    });
+  }
+
+  it("should decode a plain boolean", () => {
+    // Arrange
+    const data = { s: [], d: true };
+
+    // Act
+    const dataAsString = getDataAsString(data);
+    const result = decode(dataAsString);
+
+    // Assert
+    const expected = true;
+    expect(result).to.eql(expected);
+  });
+
+  it("should decode arrays from Zenaton serialization", () => {
+    const data = {
+      s: [
+        {
+          v: [null, 12, true, "foobar"],
+        },
+      ],
+      o: "@zenaton#0",
+    };
+
+    const dataAsString = getDataAsString(data);
+    const result = decode(dataAsString);
+
+    const expected = [null, 12, true, "foobar"];
+
+    expect(result).to.eql(expected);
+  });
+
+  it("should decode JSON", () => {
+    const data = {
+      user: {
+        name: "Louis Cibot",
+        age: 25,
+        sex: "M",
+      },
+    };
+
+    const dataAsString = JSON.stringify(data);
+    const result = decode(dataAsString);
+
+    const expected = data;
+
+    expect(result).to.eql(expected);
+  });
+});


### PR DESCRIPTION
If you launch a workflow with the `yield` code path.

And launch an event to this workflow with the `serverless` code path. It should now work!