### PR TITLE
Allow selection of workflows without name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
 
 - Change the ZENATON `LAST_CODE_PATH` to `serverless`.
+- Allow selection of workflows without name.
 
 ## 0.7.3 - 2020-01-13
 

--- a/src/Code/serverless/Client/Select.js
+++ b/src/Code/serverless/Client/Select.js
@@ -6,6 +6,11 @@ const Select = class Select {
   }
 
   workflow(name) {
+    if (!!name && typeof name !== "string") {
+      throw new ExternalZenatonError(
+        `In "select.workflow()", parameter should be a string - not a "${typeof name}"`,
+      );
+    }
     this._type = "WORKFLOW";
     this._name = name;
 

--- a/src/Code/serverless/Client/Select.js
+++ b/src/Code/serverless/Client/Select.js
@@ -6,11 +6,6 @@ const Select = class Select {
   }
 
   workflow(name) {
-    if (typeof name !== "string") {
-      throw new ExternalZenatonError(
-        `In "select.workflow()", parameter should be a string - not a "${typeof name}"`,
-      );
-    }
     this._type = "WORKFLOW";
     this._name = name;
 

--- a/src/Code/yield/Client/Select.js
+++ b/src/Code/yield/Client/Select.js
@@ -6,6 +6,11 @@ const Select = class Select {
   }
 
   workflow(name) {
+    if (!!name && typeof name !== "string") {
+      throw new ExternalZenatonError(
+        `In "select.workflow()", parameter should be a string - not a "${typeof name}"`,
+      );
+    }
     this._type = "WORKFLOW";
     this._name = name;
 

--- a/src/Code/yield/Client/Select.js
+++ b/src/Code/yield/Client/Select.js
@@ -6,11 +6,6 @@ const Select = class Select {
   }
 
   workflow(name) {
-    if (typeof name !== "string") {
-      throw new ExternalZenatonError(
-        `In "select.workflow()", parameter should be a string - not a "${typeof name}"`,
-      );
-    }
     this._type = "WORKFLOW";
     this._name = name;
 


### PR DESCRIPTION
This PR allows workflow selection such as 
```
this.select.workflow().withId("<id>")
```