### PR TITLE
Fix selector query input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed selector query input.
+
 ## 0.7.3 - 2020-01-13
 
 ### Added

--- a/src/Code/serverless/Client/Select.js
+++ b/src/Code/serverless/Client/Select.js
@@ -96,7 +96,7 @@ const Select = class Select {
       type: this._type,
       name: this._name,
       customId: this._customId,
-      instanceIntentId: this._instanceIntentId,
+      id: this._instanceIntentId,
     };
   }
 };

--- a/src/Code/yield/Client/Select.js
+++ b/src/Code/yield/Client/Select.js
@@ -96,7 +96,7 @@ const Select = class Select {
       type: this._type,
       name: this._name,
       customId: this._customId,
-      instanceIntentId: this._instanceIntentId,
+      id: this._instanceIntentId,
     };
   }
 };


### PR DESCRIPTION
This PR fixes the following error:

**Script**
```js
const { run, select } = require("./client");

async function main() {
  const job = await run.workflow("SequentialWorkflow");
  console.log(job);
  select
    .workflow("SequentialWorkflow")
    .withId(job.id)
    .send("MyEvent")
  ;
  select.workflow("SequentialWorkflow").withId(job.id).pause();
};

main();
```

**Error**
```
➜  examples-node git:(master) ✗ node launch_bug.js
Job {
  id: '11072412-c150-4e74-acc3-dbe326c2f441',
  promise: Promise { <pending> } }
(node:88378) UnhandledPromiseRejectionWarning: Error: Argument "input" has invalid value $pauseWorkflowsInput.
In field "selector": Expected type "Selector!", found {instanceIntentId: "11072412-c150-4e74-acc3-dbe326c2f441", name: "SequentialWorkflow", type: "WORKFLOW"}.
In field "instanceIntentId": Unknown field.
    at Alfred._request (/Users/yannis/Zenaton/zenaton-node/lib/Code/yield/Client/Alfred.js:349:17)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```