### PR TITLE
Allow undefined workflow name when using withId

### DIFF
--- a/src/Code/serverless/Client/Select.js
+++ b/src/Code/serverless/Client/Select.js
@@ -6,7 +6,7 @@ const Select = class Select {
   }
 
   workflow(name) {
-    if (typeof name !== "string") {
+    if (!!name && typeof name !== "string") {
       throw new ExternalZenatonError(
         `In "select.workflow()", parameter should be a string - not a "${typeof name}"`,
       );

--- a/src/Code/yield/Client/Select.js
+++ b/src/Code/yield/Client/Select.js
@@ -6,7 +6,7 @@ const Select = class Select {
   }
 
   workflow(name) {
-    if (typeof name !== "string") {
+    if (!!name && typeof name !== "string") {
       throw new ExternalZenatonError(
         `In "select.workflow()", parameter should be a string - not a "${typeof name}"`,
       );


### PR DESCRIPTION
This allows `this.select.workflow().withId("<id>").send("<event name>", ...<event data>);` to work in yield code path.